### PR TITLE
after/plugin/ -> plugin/, check if already loaded

### DIFF
--- a/plugin/cmp_buffer.lua
+++ b/plugin/cmp_buffer.lua
@@ -1,1 +1,5 @@
+if package.loaded['cmp_buffer'] then
+  return
+end
+
 require('cmp').register_source('buffer', require('cmp_buffer'))


### PR DESCRIPTION
Same as [#61] from [hrsh7th/cmp-nvim-lsp], also related to [#2021] from
[hrsh7th/nvim-cmp].

You should now be able to load the cmp source with `:packadd`, as you before was
restricted to do so because of `after/` directories not automatically being
loaded in that way. Let me know what you think.

[#61]: https://github.com/hrsh7th/cmp-nvim-lsp/pull/61
[hrsh7th/cmp-nvim-lsp]: https://github.com/hrsh7th/cmp-nvim-lsp/pull/61
[#2021]: https://github.com/hrsh7th/nvim-cmp/issues/2021
[hrsh7th/nvim-cmp]: https://github.com/hrsh7th/nvim-cmp
